### PR TITLE
Fix src/en/en.dat by escaping some backslashes

### DIFF
--- a/src/en/en.dat
+++ b/src/en/en.dat
@@ -46,13 +46,13 @@ a [Aa]
 _ [ ]['‘"“]?
 
 # pattern "vow" matches words beginning with vowels:
-vow [aeiouAEIOU]\w*
+vow [aeiouAEIOU]\\w*
 
 # pattern "con" matches words beginning with consonants:
-con [bcdfghj-np-tv-zBCDFGHJ-NP-TV-Z]\w*
+con [bcdfghj-np-tv-zBCDFGHJ-NP-TV-Z]\\w*
 
 # pattern "etc" matches other word parts separated by hyphen, endash or apostrophes:
-etc [-–'’\w]*
+etc [-–'’\\w]*
 
 # rules ("aA", "aAN", "aB" sets are defined at the end of the file)
 
@@ -134,7 +134,7 @@ punct = { "?": "question mark", "!": "exclamation mark",
 
 # multiplication sign
 
-number \d+([.]\d+)?
+number \\d+([.]\\d+)?
 
 {number}(x| x ){number} <- option("times") -> {number}×{number} # Multiplication sign. \n http://en.wikipedia.org/wiki/Multiplication_sign
 # 800x600 -> 800×600
@@ -181,7 +181,7 @@ pun [?!,:;%‰‱˚“”‘]
 
 # apostrophe
 
-w \w*
+w \\w*
 (?i){Abc}'{w} <- option("apostrophe") -> {Abc}’{w}	# Replace typewriter apostrophe or quotation mark:
 # o'clock -> o’clock
 # singers' voices -> singers’ voices
@@ -194,9 +194,9 @@ w \w*
 # Thousand separators: 10000 -> 10,000  (common) or 10 000 (ISO standard)
 
 # definitions
-d	\d\d\d		# name definition: 3 digits
-d2	\d\d		# 2 digits
-D	\d{1,3}		# 1, 2 or 3 digits
+d	\\d\\d\\d		# name definition: 3 digits
+d2	\\d\\d		# 2 digits
+D	\\d{1,3}		# 1, 2 or 3 digits
 
 # ISO thousand separators: space, here: narrow no-break space (U+202F)
 \b{d2}{d}\b 	 <- option("numsep") -> {d2},{d}\n{d2} {d}			# Use thousand separator (common or ISO).
@@ -226,72 +226,72 @@ with it['’]s <- option("grammar") -> with its\nwith, it’s # Did you mean:
 
 # Temperature
 
-([-−]?\d+(?:[,.]\d+)*) (°F|Fahrenheit) <- option("metric") -> = measurement(\1, "F", "C", u" °C", ".", ",") # Convert to Celsius:
-([-−]?\d+(?:[,.]\d+)*) (°C|Celsius) <- option("nonmetric") -> = measurement(\1, "C", "F", u" °F", ".", ",") # Convert to Fahrenheit:
+([-−]?\\d+(?:[,.]\\d+)*) (°F|Fahrenheit) <- option("metric") -> = measurement(\1, "F", "C", u" °C", ".", ",") # Convert to Celsius:
+([-−]?\\d+(?:[,.]\\d+)*) (°C|Celsius) <- option("nonmetric") -> = measurement(\1, "C", "F", u" °F", ".", ",") # Convert to Fahrenheit:
 
 # Length
 
-([-−]?\d+(?:[,.]\d+)*(?: 1/2| ?½)?) (ft|foot|feet)(?! [1-9]) <- option("metric") -> =
+([-−]?\\d+(?:[,.]\\d+)*(?: 1/2| ?½)?) (ft|foot|feet)(?! [1-9]) <- option("metric") -> =
 	measurement(\1, "ft", "cm", " cm", ".", ",") + "\n" +
 	measurement(\1, "ft", "m", " m", ".", ",") # Convert to metric:
 
-([-−]?\d+(?:[,.]\d+)*(?: 1/2| ?½)?) ft[.]? ([0-9]+(?: 1/2| ?½)?) in <- option("metric") -> =
+([-−]?\\d+(?:[,.]\\d+)*(?: 1/2| ?½)?) ft[.]? ([0-9]+(?: 1/2| ?½)?) in <- option("metric") -> =
 	measurement(\1 + "*12+" + \2, "in", "cm", " cm", ".", ",") + "\n" +
 	measurement(\1 + "*12+" + \2, "in", "m", " m", ".", ",") # Convert to metric:
 
-([-−]?\d+(?:[,.]\d+)*(?: 1/2| ?½)?) in <- option("metric") -> =
+([-−]?\\d+(?:[,.]\\d+)*(?: 1/2| ?½)?) in <- option("metric") -> =
 	measurement(\1, "in", "mm", " mm", ".", ",") + "\n" +
 	measurement(\1, "in", "cm", " cm", ".", ",") + "\n" +
 	measurement(\1, "in", "m", " m", ".", ",") # Convert to metric:
 
-([-−]?\d+(?:[,.]\d+)*) mm <- option("nonmetric") -> =
+([-−]?\\d+(?:[,.]\\d+)*) mm <- option("nonmetric") -> =
 	measurement(\1, "mm", "in", " in", ".", ",") # Convert from metric:
 
-([-−]?\d+(?:[,.]\d+)*) cm <- option("nonmetric") -> =
+([-−]?\\d+(?:[,.]\\d+)*) cm <- option("nonmetric") -> =
 	measurement(\1, "cm", "in", " in", ".", ",") + "\n" +
 	measurement(\1, "cm", "ft", " ft", ".", ",") # Convert from metric:
 
-([-−]?\d+(?:[,.]\d+)*) (m|meter|metre) <- option("nonmetric") -> =
+([-−]?\\d+(?:[,.]\\d+)*) (m|meter|metre) <- option("nonmetric") -> =
 	measurement(\1, "m", "in", " in", ".", ",") + "\n" +
 	measurement(\1, "m", "ft", " ft", ".", ",") + "\n" +
 	measurement(\1, "m", "mi", " mi", ".", ",") # Convert from metric:
 
-([-−]?\d+(?:[,.]\d+)*(?: 1/2| ?½)?) miles? <- option("metric") -> =
+([-−]?\\d+(?:[,.]\\d+)*(?: 1/2| ?½)?) miles? <- option("metric") -> =
 	measurement(\1, "mi", "m", " m", ".", ",") + "\n" +
 	measurement(\1, "mi", "km", " km", ".", ",") # Convert to metric:
 
-([-−]?\d+(?:[,.]\d+)*) km <- option("nonmetric") -> =
+([-−]?\\d+(?:[,.]\\d+)*) km <- option("nonmetric") -> =
 	measurement(\1, "km", "mi", " mi", ".", ",") # Convert to miles:
 
-([-−]?\d+(?:,\d+)?) (yd|yards?) <- option("metric") -> = measurement(\1, "yd", "m", " m", ".", ",") # Convert to metric:
+([-−]?\\d+(?:,\\d+)?) (yd|yards?) <- option("metric") -> = measurement(\1, "yd", "m", " m", ".", ",") # Convert to metric:
 
 # Volume
 
-([-−]?\d+(?:,\d+)?) (gal(lons?)?) <- option("metric") -> =
+([-−]?\\d+(?:,\\d+)?) (gal(lons?)?) <- option("metric") -> =
 	measurement(\1, "gal", "l", " l", ".", ",") + "\n" + 
 	measurement(\1, "uk_gal", "l", " l (in UK)", ".", ",") # Convert to metric:
 
-([-−]?\d+(?:,\d+)?) (pint) <- option("metric") -> = 
+([-−]?\\d+(?:,\\d+)?) (pint) <- option("metric") -> = 
 	measurement(\1, "pt", "dl", " dl", ".", ",") + "\n" + 
 	measurement(\1, "uk_pt", "dl", " dl (in UK)", ".", ",") + "\n" +
 	measurement(\1, "pt", "l", " l", ".", ",") + "\n" + 
 	measurement(\1, "uk_pt", "l", " l (in UK)", ".", ",") # Convert to metric:
 
-([-−]?\d+(?:,\d+)?) (l|L|litres?|liters?) <- option("nonmetric") -> =
+([-−]?\\d+(?:,\\d+)?) (l|L|litres?|liters?) <- option("nonmetric") -> =
 	measurement(\1, "l", "gal", " gal", ".", ",") + "\n" + 
 	measurement(\1, "l", "gal", " gal (in UK)", ".", ",") # Convert to gallons:
 
 # Weight
 
-([-−]?\d+(?:[,.]\d+)*) lbs?[.]? <- option("metric") -> =
+([-−]?\\d+(?:[,.]\\d+)*) lbs?[.]? <- option("metric") -> =
 	measurement(\1, "lbm", "kg", " kg", ".", ",") # Convert to metric:
-([-−]?\d+(?:[,.]\d+)*) kg[.]? <- option("nonmetric") -> =
+([-−]?\\d+(?:[,.]\\d+)*) kg[.]? <- option("nonmetric") -> =
 	measurement(\1, "kg", "lbm", " lb", ".", ",") # Convert to pounds:
 
 # Speed
 
-([-−]?\d+(?:[,.]\d+)*) mph <- option("metric") -> = measurement(\1, "mph", "km/h", " km/h", ".", ",") # Convert to km/hour:
-([-−]?\d+(?:[,.]\d+)*) km/h <- option("nonmetric") -> = measurement(\1, "km/h", "mph", " mph", ".", ",") # Convert to miles/hour:
+([-−]?\\d+(?:[,.]\\d+)*) mph <- option("metric") -> = measurement(\1, "mph", "km/h", " km/h", ".", ",") # Convert to km/hour:
+([-−]?\\d+(?:[,.]\\d+)*) km/h <- option("nonmetric") -> = measurement(\1, "km/h", "mph", " mph", ".", ",") # Convert to miles/hour:
 
 [code]
 


### PR DESCRIPTION
Fix this kind of error:
make.py:37: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  fArgs = cp.SafeConfigParser()
Traceback (most recent call last):
  File "/usr/lib/python3.7/sre_parse.py", line 1021, in parse_template
    this = chr(ESCAPES[this][1])
KeyError: '\\d'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "make.py", line 41, in <module>
    dist(i[:-4], fArgs._sections['args'])
  File "make.py", line 13, in dist
    code = pythonpath.lightproof_compile___implname__.c(f.read(), a['lang'])
  File "/home/julien/projects/julien/libreoffice-lightproof/pythonpath/lightproof_compile___implname__.py", line 270, in c
    item = mysplit(lines[i].strip(), i + 1, oldlinenums[lines[i]], debug)
  File "/home/julien/projects/julien/libreoffice-lightproof/pythonpath/lightproof_compile___implname__.py", line 104, in mysplit
    s1 = re.sub("[{]" + i + "}", repl[i], s1)
  File "/usr/lib/python3.7/re.py", line 192, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/usr/lib/python3.7/re.py", line 309, in _subx
    template = _compile_repl(template, pattern)
  File "/usr/lib/python3.7/re.py", line 300, in _compile_repl
    return sre_parse.parse_template(repl, pattern)
  File "/usr/lib/python3.7/sre_parse.py", line 1024, in parse_template
    raise s.error('bad escape %s' % this, len(this))
re.error: bad escape \d at position 11

Remark: I don't know why some don't need this escaping.
eg "\b":
\b{d2}{d}\b      <- option("numsep") -> {d2},{d}\n{d2} {d}